### PR TITLE
Describe what codoc adds in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # codoc
 
-**codoc** is a new OCaml documentation tool. It does not impose any
+**codoc** is a new OCaml documentation tool **which allows to/which adds …**. It does not impose any
   specific package manager on you or assume a specific
   workflow. **codoc** requires at least **OCaml** `4.02.2`.
 


### PR DESCRIPTION
As new comer, when I see the README, I don't understand why I would change to `codoc`
